### PR TITLE
Bids and search-results pages spacing fix

### DIFF
--- a/src/bids/bids.scss
+++ b/src/bids/bids.scss
@@ -1170,7 +1170,7 @@
 				margin: 15px 0 0 0;
 
 				@media (min-width: $screen-lg-min) {
-					margin: 25px 0 0 0;
+					//margin: 25px 0 0 0;
 				}
 			}
 		}
@@ -1237,17 +1237,36 @@
 		}
 
 		.related-bid-wrapper {
-			padding: 23px 34px 11px 16px;
+			padding: 23px 34px 23px 16px;
+
+			@media (min-width: $screen-lg-min) {
+				padding: 23px 30px 16px 16px;
+			}
+
+			@media (min-width: $screen-xl-min) {
+				padding: 23px 40px 16px 16px;
+			}	
 		}
 
 		.slide {
-			width: 293px;
-			min-height: 239px;
+			width: 100%;
+			max-width: 293px;
+			//min-height: 239px;
 			border-radius: 2.1px;
 			background-color: $main-white;
 			box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.15);
 			position: relative;
 			margin: 0 0 0 10px;
+
+			@media (min-width: $screen-lg-min) {
+				max-width: 230px;
+				//min-height: 220px;
+			}
+
+			@media (min-width: $screen-xl-min) {
+				max-width: 293px;
+				//min-height: 239px;
+			}	
 
 			&:last-child {
 				margin: 0;

--- a/src/common/common.scss
+++ b/src/common/common.scss
@@ -18,6 +18,11 @@ html {
   @media (min-width: $screen-xl-min) {
     font-size: 10px;
   }
+
+  .eng-in-heb {
+    font-size: 80%;
+    font-weight: inherit;
+  }
 }
 
 body {

--- a/src/search-results/index.html
+++ b/src/search-results/index.html
@@ -588,15 +588,24 @@
 
                     <!-- result link -->
                     <a class="result-link" href="../bids/index.html" tabindex="0">
-                      <h2>אספקת מחשבים עבור משרדי ממשלה</h2>
+                      <h2>האצת פרישת רשת החלקה להפחתת לחץ. ומדידה למתקני 
+
+                      <!-- add "eng-in-heb" class to any english words in hebrew pages    -->
+                      <span class="eng-in-heb">PRMS</span>
+                      </h2>
                     </a>
                     <div class="details-wrapper">
                       <!-- name -->
                       <span>מפרסם: </span><span class="font-weight-normal">משרד האוצר- מנהל הרכש הממשלתי</span><br>
 
+                      <!-- serial number -->
+                      <span>מספר סידורי: </span><span class="font-weight-normal">0000000000</span>
+                      <span class="font-weight-normal"> | </span>
+
                       <!-- status (Change class according to status and color changes: new, updated, closed, pre-committees-decision, cancelled) -->
                       <span>סטטוס: </span><span class="status updated font-weight-normal">מעודכן</span>
-                      <span class="font-weight-normal"> | </span>
+                       <span class="font-weight-normal d-none d-lg-inline-block">|</span>
+                      <br class="d-lg-none">
 
                       <!-- process number -->
                       <span>מספר הליך: </span><span class="font-weight-normal number">18-2017</span> <span class="font-weight-normal d-none d-lg-inline-block">|</span>
@@ -657,9 +666,14 @@
                       <!-- name -->
                       <span>מפרסם: </span><span class="font-weight-normal">משרד האוצר- מנהל הרכש הממשלתי</span><br>
 
+                      <!-- serial number -->
+                      <span>מספר סידורי: </span><span class="font-weight-normal">0000000000</span>
+                      <span class="font-weight-normal"> | </span>
+
                       <!-- status (Change class according to status and color changes: new, updated, closed, pre-committees-decision, cancelled) -->
                       <span>סטטוס: </span><span class="status updated font-weight-normal">מעודכן</span>
-                      <span class="font-weight-normal"> | </span>
+                      <span class="font-weight-normal d-none d-lg-inline-block"> | </span>
+                      <br class="d-lg-none">
 
                       <!-- process number -->
                       <span>מספר הליך: </span><span class="font-weight-normal number">18-2017</span> <span class="font-weight-normal d-none d-lg-inline-block">|</span>
@@ -721,9 +735,14 @@
                       <!-- name -->
                       <span>מפרסם: </span><span class="font-weight-normal">משרד האוצר- מנהל הרכש הממשלתי</span><br>
 
+                      <!-- serial number -->
+                      <span>מספר סידורי: </span><span class="font-weight-normal">0000000000</span>
+                      <span class="font-weight-normal"> | </span>
+
                       <!-- status (Change class according to status and color changes: new, updated, closed, pre-committees-decision, cancelled) -->
                       <span>סטטוס: </span><span class="status updated font-weight-normal">מעודכן</span>
-                      <span class="font-weight-normal"> | </span>
+                      <span class="font-weight-normal d-none d-lg-inline-block"> | </span>
+                      <br class="d-lg-none">
 
                       <!-- process number -->
                       <span>מספר הליך: </span><span class="font-weight-normal number">18-2017</span> <span class="font-weight-normal d-none d-lg-inline-block">|</span>

--- a/src/search-results/search-results.scss
+++ b/src/search-results/search-results.scss
@@ -693,17 +693,21 @@
 					font-size: 2rem;
 					line-height: 1;
 					font-weight: normal;
-					margin: 0 0 20px 70px;
+					margin: 0 0 8px 70px;
 
 					@media (min-width: $screen-lg-min) {
 						font-size: 3.2rem;
 						font-style: normal;
 						font-stretch: normal;
-						line-height: 0.78;
+						//line-height: 0.78;
 						letter-spacing: normal;
 						color: $text-dark-grey;
-						margin: 0 0 14px 0;
+						margin: 0 0 4px 0;
 						max-width: none;
+					}
+
+					.eng-in-heb {
+						font-weight: normal;
 					}
 				}
 			}
@@ -765,7 +769,7 @@
 				color: #505050;
 
 				@media (min-width: $screen-lg-min) {
-					margin: 0 0 24px 0;
+					margin: 0 0 24px 50px;
 					font-size: 2rem;
 				}
 
@@ -864,7 +868,7 @@
 				}
 
 				.details-wrapper {
-					max-width: 695px;
+					//max-width: 695px;
 				}
 
 				h2 {
@@ -872,7 +876,7 @@
 					color: $header-blue;
 
 					@media (min-width: $screen-lg-min) {
-						max-width: 520px;
+						//max-width: 520px;
 					}
 				}
 				


### PR DESCRIPTION
1. bids slide spacing fixed (no HTML changes)

2. search-results spacing of the content in the result (HTML changes)

HTML changes:
Wrap words in English in Hebrew pages with a span, and give it the class "eng-in-heb". 